### PR TITLE
Cassandra compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,12 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,11 +351,11 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 name = "seella"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
  "csv",
  "serde",
+ "thiserror",
  "uuid",
 ]
 
@@ -400,6 +394,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.4", features = ["serde"] }
 clap = { version = "4.3", features = ["derive"] }
 csv = "1.2"
-anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1.0.47"

--- a/README.md
+++ b/README.md
@@ -7,57 +7,57 @@ Generates waterfall charts and a tree diagram of `system_tracing.events` in your
 Basic invocation:
 
 ```text
-❯ seella 74fe2f40-397b-11ee-8ca4-9688db6cc0f1
+❯ seella 74ff67c0-397b-11ee-8ca4-9688db6cc0f1
 
-Session ID: 74fe2f40-397b-11ee-8ca4-9688db6cc0f1
-2023-08-13T01:48:10.164+00:00
+Session ID: 74ff67c0-397b-11ee-8ca4-9688db6cc0f1
+2023-08-13T01:48:10.172+00:00
 172.17.0.2      (anonymous) -> 172.17.0.2
 Request Size:  84
 Response Size: 20
-QUERY Execute CQL3 query
-"{'consistency_level': 'ONE', 'page_size': '100', 'query': 'INSERT INTO k.t (pk, t, v, s) VALUES (0, 0, ''val0'', ''static0'');', 'serial_consistency_level': 'SERIAL', 'user_timestamp': '1691891290164607'}"
+Execute CQL3 query
+"{'consistency_level': 'ONE', 'page_size': '100', 'query': 'INSERT INTO k.t (pk, t, v, s) VALUES (0, 1, ''val1'', ''static1'');', 'serial_consistency_level': 'SERIAL', 'user_timestamp': '1691891290172041'}"
 
    waterfall chart                                                                                        dur    node                activity
  1 [█─────┤                                                                                             ] 0      172.17.0.2      ├┬─ Parsing a statement
- 2 [█                                                                                                   ] 17     172.17.0.3      │├─ Message received from /172.17.0.2
- 3 [███                                                                                                 ] 195    172.17.0.3      │├─ Sending mutation_done to /172.17.0.2
- 4 [   ████                                                                                             ] 202    172.17.0.3      │├─ Mutation handling is done
- 5 [       ██                                                                                           ] 86     172.17.0.2      ├── Processing a statement
- 6 [         ███                                                                                        ] 158    172.17.0.2      ├── Creating write handler for token: -3485513579396041028 natural: {172.17.0.3} pending: {}
- 7 [            ███                                                                                     ] 163    172.17.0.2      ├── Creating write handler with live: {172.17.0.3} dead: {}
- 8 [               ███                                                                                  ] 173    172.17.0.2      ├── Sending a mutation to /172.17.0.3
- 9 [                  ████████████████████                                                              ] 1109   172.17.0.2      ├── Got a response from /172.17.0.3
-10 [                                      ████████████████████                                          ] 1111   172.17.0.2      ├── Delay decision due to throttling: do not delay, resuming now
-11 [                                                          █████████████████████                     ] 1120   172.17.0.2      ├── Mutation successfully completed
-12 [                                                                               █████████████████████] 1128   172.17.0.2      ├── Done processing - preparing a result
+ 2 [█                                                                                                   ] 5      172.17.0.3      │├─ Message received from /172.17.0.2
+ 3 [███                                                                                                 ] 55     172.17.0.3      │├─ Sending mutation_done to /172.17.0.2
+ 4 [   ████                                                                                             ] 58     172.17.0.3      │├─ Mutation handling is done
+ 5 [       █                                                                                            ] 27     172.17.0.2      ├── Processing a statement
+ 6 [        ███                                                                                         ] 45     172.17.0.2      ├── Creating write handler for token: -3485513579396041028 natural: {172.17.0.3} pending: {}
+ 7 [           ███                                                                                      ] 46     172.17.0.2      ├── Creating write handler with live: {172.17.0.3} dead: {}
+ 8 [              ███                                                                                   ] 49     172.17.0.2      ├── Sending a mutation to /172.17.0.3
+ 9 [                 ████████████████████                                                               ] 332    172.17.0.2      ├── Got a response from /172.17.0.3
+10 [                                     █████████████████████                                          ] 333    172.17.0.2      ├── Delay decision due to throttling: do not delay, resuming now
+11 [                                                          ████████████████████                      ] 339    172.17.0.2      ├── Mutation successfully completed
+12 [                                                                              ██████████████████████] 344    172.17.0.2      ├── Done processing - preparing a result
 ```
 
 Or one with more options:
 
 ```text
-❯ seella -w 50 --show-event-id --show-span-ids --show-thread --max-activity-width 50 74fe2f40-397b-11ee-8ca4-9688db6cc0f1
+❯ seella -w 50 --show-event-id --show-span-ids --show-thread --max-activity-width 50 74ff67c0-397b-11ee-8ca4-9688db6cc0f1
 
-Session ID: 74fe2f40-397b-11ee-8ca4-9688db6cc0f1
-2023-08-13T01:48:10.164+00:00
+Session ID: 74ff67c0-397b-11ee-8ca4-9688db6cc0f1
+2023-08-13T01:48:10.172+00:00
 172.17.0.2      (anonymous) -> 172.17.0.2
 Request Size:  84
 Response Size: 20
-QUERY Execute CQL3 query
-"{'consistency_level': 'ONE', 'page_size': '100', 'query': 'INSERT INTO k.t (pk, t, v, s) VALUES (0, 0, ''val0'', ''static0'');', 'serial_consistency_level': 'SERIAL', 'user_timestamp': '1691891290164607'}"
+Execute CQL3 query
+"{'consistency_level': 'ONE', 'page_size': '100', 'query': 'INSERT INTO k.t (pk, t, v, s) VALUES (0, 1, ''val1'', ''static1'');', 'serial_consistency_level': 'SERIAL', 'user_timestamp': '1691891290172041'}"
 
    waterfall chart                                      dur    node                activity                                           event id                              span id              parent span id       thread name
- 1 [█─┤                                               ] 0      172.17.0.2      ├┬─ Parsing a statement                                74fe4ff1-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
- 2 [█                                                 ] 17     172.17.0.3      │├─ Message received from /172.17.0.2                  74fe5af7-397b-11ee-a288-20cc230d8ac0  332802293968211      215842640618669      shard 4
- 3 [█                                                 ] 195    172.17.0.3      │├─ Sending mutation_done to /172.17.0.2               74fe61ec-397b-11ee-a288-20cc230d8ac0  332802293968211      215842640618669      shard 4
- 4 [ ██                                               ] 202    172.17.0.3      │├─ Mutation handling is done                          74fe622b-397b-11ee-a288-20cc230d8ac0  332802293968211      215842640618669      shard 4
- 5 [   █                                              ] 86     172.17.0.2      ├── Processing a statement                             74fe534a-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
- 6 [    ██                                            ] 158    172.17.0.2      ├── Creating write handler for token: -348551357939604 74fe5621-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
- 7 [      █                                           ] 163    172.17.0.2      ├── Creating write handler with live: {172.17.0.3} dea 74fe564f-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
- 8 [       ██                                         ] 173    172.17.0.2      ├── Sending a mutation to /172.17.0.3                  74fe56b5-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
- 9 [         ██████████                               ] 1109   172.17.0.2      ├── Got a response from /172.17.0.3                    74fe7b45-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
-10 [                   ██████████                     ] 1111   172.17.0.2      ├── Delay decision due to throttling: do not delay, re 74fe7b55-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
-11 [                             ██████████           ] 1120   172.17.0.2      ├── Mutation successfully completed                    74fe7bae-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
-12 [                                       ███████████] 1128   172.17.0.2      ├── Done processing - preparing a result               74fe7bfe-397b-11ee-8ca4-9688db6cc0f1  215842640618669      0                    shard 0
+ 1 [█─┤                                               ] 0      172.17.0.2      ├┬─ Parsing a statement                                74ff70c8-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+ 2 [█                                                 ] 5      172.17.0.3      │├─ Message received from /172.17.0.2                  74ff75b2-397b-11ee-a288-20cc230d8ac0  343569500103777      153249663699531      shard 4
+ 3 [█                                                 ] 55     172.17.0.3      │├─ Sending mutation_done to /172.17.0.2               74ff779d-397b-11ee-a288-20cc230d8ac0  343569500103777      153249663699531      shard 4
+ 4 [ ██                                               ] 58     172.17.0.3      │├─ Mutation handling is done                          74ff77c2-397b-11ee-a288-20cc230d8ac0  343569500103777      153249663699531      shard 4
+ 5 [   █                                              ] 27     172.17.0.2      ├── Processing a statement                             74ff71dc-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+ 6 [    █                                             ] 45     172.17.0.2      ├── Creating write handler for token: -348551357939604 74ff728a-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+ 7 [     ██                                           ] 46     172.17.0.2      ├── Creating write handler with live: {172.17.0.3} dea 74ff7296-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+ 8 [       █                                          ] 49     172.17.0.2      ├── Sending a mutation to /172.17.0.3                  74ff72b1-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+ 9 [        ██████████                                ] 332    172.17.0.2      ├── Got a response from /172.17.0.3                    74ff7dc2-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+10 [                  ███████████                     ] 333    172.17.0.2      ├── Delay decision due to throttling: do not delay, re 74ff7dcb-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+11 [                             ██████████           ] 339    172.17.0.2      ├── Mutation successfully completed                    74ff7e09-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
+12 [                                       ███████████] 344    172.17.0.2      ├── Done processing - preparing a result               74ff7e3a-397b-11ee-8ca4-9688db6cc0f1  153249663699531      0                    shard 0
 ```
 
 ## Usage

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use uuid::Uuid;
 
 /// A source for the data based on an exported CSV.
+#[derive(Debug)]
 pub struct CsvSource<'a> {
     sessions: &'a PathBuf,
     events: &'a PathBuf,

--- a/src/csv.rs
+++ b/src/csv.rs
@@ -1,0 +1,78 @@
+use crate::data_source::DataSource;
+use crate::records::{EventRecord, SessionRecord};
+use std::{fs::File, io::BufReader, path::PathBuf};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// A source for the data based on an exported CSV.
+pub struct CsvSource<'a> {
+    sessions: &'a PathBuf,
+    events: &'a PathBuf,
+    session_id: Uuid,
+}
+
+impl<'a> CsvSource<'a> {
+    pub fn new(sessions: &'a PathBuf, events: &'a PathBuf, session_id: Uuid) -> Self {
+        Self {
+            sessions,
+            events,
+            session_id,
+        }
+    }
+}
+
+/// The kinds of errors that can be experienced while parsing the data from the CSV.
+#[derive(Debug, Error)]
+pub enum CsvParsingError {
+    #[error("the provided session id {0} could not be found")]
+    SessionNotFound(Uuid),
+    #[error("there were issues deserializing the session data")]
+    SessionDeserializationErrors(Vec<csv::Error>),
+    #[error("there were issues deserializing the event data")]
+    EventDeserializationErrors(Vec<csv::Error>),
+    #[error("there were issues finding the files")]
+    IoError(#[from] std::io::Error),
+}
+
+impl<'a> DataSource for CsvSource<'a> {
+    type Error = CsvParsingError;
+
+    fn get_data(&self) -> Result<(SessionRecord, Vec<EventRecord>), Self::Error> {
+        let mut session_deserialization_errors = Vec::new();
+        let session_record = csv::Reader::from_reader(BufReader::new(File::open(self.sessions)?))
+            .deserialize::<SessionRecord>()
+            .filter_map(|record_res| {
+                record_res
+                    .map_err(|err| session_deserialization_errors.push(err))
+                    .ok()
+            })
+            .find(|record| record.session_id == self.session_id)
+            .ok_or(CsvParsingError::SessionNotFound(self.session_id))?;
+
+        if !session_deserialization_errors.is_empty() {
+            return Err(CsvParsingError::SessionDeserializationErrors(
+                session_deserialization_errors,
+            ));
+        }
+
+        let mut event_deserialization_errors = Vec::new();
+        let event_records: Vec<EventRecord> =
+            csv::Reader::from_reader(BufReader::new(File::open(self.events)?))
+                .deserialize::<EventRecord>()
+                .filter_map(|record_res| {
+                    record_res
+                        .map_err(|err| event_deserialization_errors.push(err))
+                        .ok()
+                })
+                .filter(|record| record.session_id == self.session_id)
+                .collect();
+
+        if !event_deserialization_errors.is_empty() {
+            return Err(CsvParsingError::EventDeserializationErrors(
+                event_deserialization_errors,
+            ));
+        }
+
+        Ok((session_record, event_records))
+    }
+}

--- a/src/data_source.rs
+++ b/src/data_source.rs
@@ -1,0 +1,8 @@
+use crate::records::{EventRecord, SessionRecord};
+
+/// Generalises the ability to get the [SessionRecord] and [EventRecords][EventRecord] from anywhere.
+pub trait DataSource {
+    type Error;
+
+    fn get_data(&self) -> Result<(SessionRecord, Vec<EventRecord>), Self::Error>;
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -128,11 +128,6 @@ impl Event {
                 .expect(COMPLAIN_ABOUT_TRACE_SIZE),
         }
         .to_string();
-        let source = self.source.to_string();
-        let activity = &self.activity;
-        let event_id = self.id.to_string();
-        let span_id = self.span_id.to_string();
-        let parent_span_id = self.parent_span_id.to_string();
 
         // Activity tree
         let mut tree_bit = format!("{:│>t_depth$}", "├", t_depth = depth + 1);
@@ -145,12 +140,12 @@ impl Event {
             config,
             min_activity_width,
             &duration,
-            &source,
+            &self.source.to_string(),
             &tree,
-            activity,
-            &event_id,
-            &span_id,
-            &parent_span_id,
+            &self.activity,
+            &self.id.to_string(),
+            &self.span_id.to_string(),
+            &self.parent_span_id.to_string(),
             &self.thread,
         )
     }
@@ -253,7 +248,7 @@ pub fn event_display_str(
 }
 
 /// Wrapper type for the `i64` used by Scylla for span IDs.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, Default)]
 pub struct SpanId(i64);
 
 impl SpanId {

--- a/src/event.rs
+++ b/src/event.rs
@@ -6,14 +6,26 @@ use uuid::Uuid;
 /// All of the information related to an event, as well as all child events.
 #[derive(Debug)]
 pub struct Event {
+    /// The UUID of the Event
     pub id: Uuid,
+    /// The UUID of the Session
     pub session_id: Uuid,
-    pub span_id: SpanId,
-    pub parent_span_id: SpanId,
+    /// What is being done in this Event
     pub activity: String,
+    /// The source IP for this Event
     pub source: IpAddr,
+    /// Duration of this only this Event, not including child events
     pub duration: Duration,
+    /// The name of the thread from which this Event originated
     pub thread: String,
+
+    /// Unique identifier for this Event's span
+    /// Not present in Cassandra
+    pub span_id: SpanId,
+    /// Span ID for this Event's parent. Used to identity the tree structure
+    /// Not present in Cassandra
+    pub parent_span_id: SpanId,
+
     child_events: Vec<Event>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use {
     session::Session,
 };
 
-pub(crate) const COMPLAIN_ABOUT_TRACE_SIZE: &str =
+pub const COMPLAIN_ABOUT_TRACE_SIZE: &str =
     "what are you doing with 2^63 microseconds in a single trace!";
 
 /// Constructs a Session instance from the files given in the [cli][Cli] config.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 //! A tool for visualising the traces emitted by ScyllaDB.
 
 mod cli;
+mod csv;
+mod data_source;
 mod event;
 mod records;
 mod session;
 
-use crate::records::{EventRecord, SessionRecord};
-use anyhow::{anyhow, bail};
-use std::{fs::File, io::BufReader};
 use uuid::Uuid;
 
 pub use {
+    crate::csv::{CsvParsingError, CsvSource},
     cli::Cli,
+    data_source::DataSource,
     event::{event_display_str, Event, SpanId},
     session::Session,
 };
@@ -23,55 +24,10 @@ pub(crate) const COMPLAIN_ABOUT_TRACE_SIZE: &str =
 ///
 /// This [Session] instance contains all of the information available from the `session.csv` file, as well as all
 /// of the information for the [events][Event] relating to that session from the `events.csv` file.
-pub fn session_from_config(cli: &Cli) -> anyhow::Result<Session> {
+pub fn session_from_config(cli: &Cli) -> Result<Session, Box<dyn std::error::Error>> {
     let session_id = Uuid::try_parse(&cli.session_id)?;
-
-    let mut session_deserialization_errors = Vec::new();
-    let session_record = csv::Reader::from_reader(BufReader::new(File::open(&cli.sessions_path)?))
-        .deserialize::<SessionRecord>()
-        .filter_map(|record_res| {
-            record_res
-                .map_err(|err| session_deserialization_errors.push(err))
-                .ok()
-        })
-        .find(|record| record.session_id == session_id)
-        .ok_or(anyhow!(
-            "could not find the session with id: {}",
-            session_id
-        ))?;
-
-    if !session_deserialization_errors.is_empty() {
-        for error in session_deserialization_errors {
-            eprintln!("{}", error);
-        }
-        bail!(
-            "errors were experienced deserializing sessions from {:?}",
-            &cli.sessions_path
-        );
-    }
-
-    let mut event_deserialization_errors = Vec::new();
-    let event_records: Vec<EventRecord> =
-        csv::Reader::from_reader(BufReader::new(File::open(&cli.events_path)?))
-            .deserialize::<EventRecord>()
-            .filter_map(|record_res| {
-                record_res
-                    .map_err(|err| event_deserialization_errors.push(err))
-                    .ok()
-            })
-            .filter(|record| record.session_id == session_id)
-            .collect();
-
-    if !event_deserialization_errors.is_empty() {
-        for error in event_deserialization_errors {
-            eprintln!("{}", error);
-        }
-
-        bail!(
-            "errors were experienced deserializing events from {:?}",
-            &cli.events_path
-        );
-    }
+    let (session_record, event_records) =
+        CsvSource::new(&cli.sessions_path, &cli.events_path, session_id).get_data()?;
 
     Ok(Session::new(session_record, event_records))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub fn session_from_config(cli: &Cli) -> anyhow::Result<Session> {
                 .map_err(|err| session_deserialization_errors.push(err))
                 .ok()
         })
-        .find(|record| record.id() == session_id)
+        .find(|record| record.session_id == session_id)
         .ok_or(anyhow!(
             "could not find the session with id: {}",
             session_id
@@ -59,7 +59,7 @@ pub fn session_from_config(cli: &Cli) -> anyhow::Result<Session> {
                     .map_err(|err| event_deserialization_errors.push(err))
                     .ok()
             })
-            .filter(|record| record.session_id() == session_id)
+            .filter(|record| record.session_id == session_id)
             .collect();
 
     if !event_deserialization_errors.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,11 @@ pub use {
     cli::Cli,
     data_source::DataSource,
     event::{event_display_str, Event, SpanId},
+    records::{EventRecord, SessionRecord},
     session::Session,
 };
 
+/// It's possible for a [chrono::Duration] to have more than 2^63 microseconds and overflow, we ignore that possibility.
 pub const COMPLAIN_ABOUT_TRACE_SIZE: &str =
     "what are you doing with 2^63 microseconds in a single trace!";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,11 +10,25 @@ fn main() -> anyhow::Result<()> {
     println!("{}", &s.started_at.to_rfc3339());
     println!(
         "{:15} ({}) -> {:15}",
-        &s.client, &s.username, &s.coordinator
+        &s.client,
+        &s.username
+            .clone()
+            .unwrap_or_else(|| String::from("unknown user")),
+        &s.coordinator
     );
-    println!("Request Size:  {}", &s.request_size);
-    println!("Response Size: {}", &s.response_size);
-    println!("{} {}", &s.command, &s.request);
+    println!(
+        "Request Size:  {}",
+        &s.request_size
+            .map(|rs| rs.to_string())
+            .unwrap_or_else(|| String::from("N/A"))
+    );
+    println!(
+        "Response Size: {}",
+        &s.response_size
+            .map(|rs| rs.to_string())
+            .unwrap_or_else(|| String::from("N/A"))
+    );
+    println!("{}", &s.request);
     println!("{:?}", &s.parameters);
 
     // Calculations for the waterfall boxes

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "{:15} ({}) -> {:15}",
         &s.client,
-        &s.username
-            .clone()
-            .unwrap_or_else(|| String::from("unknown user")),
+        &s.username.clone().unwrap_or_else(|| String::from("N/A")),
         &s.coordinator
     );
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use seella::{event_display_str, session_from_config, Cli};
 
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let s = session_from_config(&cli)?;
 

--- a/src/records.rs
+++ b/src/records.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 use std::net::IpAddr;
 use uuid::Uuid;
 
+/// The basic structure and data of a Session, before it is made into the head of a tree.
 #[derive(Debug, Deserialize)]
 pub struct SessionRecord {
     pub session_id: Uuid,
@@ -24,6 +25,7 @@ pub struct SessionRecord {
     pub username: Option<String>,
 }
 
+/// The basic structure and data of a Event, before it is made into the leaves of a tree.
 #[derive(Debug, Deserialize)]
 pub struct EventRecord {
     pub session_id: Uuid,

--- a/src/records.rs
+++ b/src/records.rs
@@ -1,3 +1,4 @@
+use crate::SpanId;
 use chrono::{DateTime, FixedOffset};
 use serde::Deserialize;
 use std::net::IpAddr;
@@ -12,32 +13,15 @@ pub struct SessionRecord {
     pub(crate) duration: i32,
     pub(crate) parameters: String,
     pub(crate) request: String,
-    pub(crate) request_size: i32,
-    pub(crate) response_size: i32,
     pub(crate) started_at: DateTime<FixedOffset>,
-    pub(crate) username: String,
-}
 
-impl SessionRecord {
-    pub fn id(&self) -> Uuid {
-        self.session_id
-    }
-
-    pub fn command(&self) -> String {
-        self.command.clone()
-    }
-
-    pub fn parameters(&self) -> String {
-        self.parameters.clone()
-    }
-
-    pub fn request(&self) -> String {
-        self.request.clone()
-    }
-
-    pub fn username(&self) -> String {
-        self.username.clone()
-    }
+    // The following are not present in Cassandra:
+    #[serde(default)]
+    pub(crate) request_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
+    #[serde(default)]
+    pub(crate) response_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
+    #[serde(default)]
+    pub(crate) username: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -45,27 +29,13 @@ pub struct EventRecord {
     pub(crate) session_id: Uuid,
     pub(crate) event_id: Uuid,
     pub(crate) activity: String,
-    pub(crate) scylla_parent_id: i64,
-    pub(crate) scylla_span_id: i64,
     pub(crate) source: IpAddr,
     pub(crate) source_elapsed: i32,
     pub(crate) thread: String,
-}
 
-impl EventRecord {
-    pub fn id(&self) -> Uuid {
-        self.event_id
-    }
-
-    pub fn session_id(&self) -> Uuid {
-        self.session_id
-    }
-
-    pub fn activity(&self) -> String {
-        self.activity.clone()
-    }
-
-    pub fn thread(&self) -> String {
-        self.thread.clone()
-    }
+    // The following are not present in Cassandra:
+    #[serde(default)]
+    pub(crate) scylla_parent_id: Option<SpanId>,
+    #[serde(default)]
+    pub(crate) scylla_span_id: Option<SpanId>,
 }

--- a/src/records.rs
+++ b/src/records.rs
@@ -6,36 +6,36 @@ use uuid::Uuid;
 
 #[derive(Debug, Deserialize)]
 pub struct SessionRecord {
-    pub(crate) session_id: Uuid,
-    pub(crate) client: IpAddr,
-    pub(crate) command: String,
-    pub(crate) coordinator: IpAddr,
-    pub(crate) duration: i32,
-    pub(crate) parameters: String,
-    pub(crate) request: String,
-    pub(crate) started_at: DateTime<FixedOffset>,
+    pub session_id: Uuid,
+    pub client: IpAddr,
+    pub command: String,
+    pub coordinator: IpAddr,
+    pub duration: i32,
+    pub parameters: String,
+    pub request: String,
+    pub started_at: DateTime<FixedOffset>,
 
     // The following are not present in Cassandra:
     #[serde(default)]
-    pub(crate) request_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
+    pub request_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
     #[serde(default)]
-    pub(crate) response_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
+    pub response_size: Option<u32>, // Strictly speaking, the int type in Scylla is signed, but it doesn't make sense for a size to be negative.
     #[serde(default)]
-    pub(crate) username: Option<String>,
+    pub username: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct EventRecord {
-    pub(crate) session_id: Uuid,
-    pub(crate) event_id: Uuid,
-    pub(crate) activity: String,
-    pub(crate) source: IpAddr,
-    pub(crate) source_elapsed: i32,
-    pub(crate) thread: String,
+    pub session_id: Uuid,
+    pub event_id: Uuid,
+    pub activity: String,
+    pub source: IpAddr,
+    pub source_elapsed: i32,
+    pub thread: String,
 
     // The following are not present in Cassandra:
     #[serde(default)]
-    pub(crate) scylla_parent_id: Option<SpanId>,
+    pub scylla_parent_id: Option<SpanId>,
     #[serde(default)]
-    pub(crate) scylla_span_id: Option<SpanId>,
+    pub scylla_span_id: Option<SpanId>,
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -44,14 +44,14 @@ pub struct Session {
     /// Size of the request
     /// Since Scylla 3.0
     /// Not present in Cassandra
-    pub request_size: i32,
+    pub request_size: Option<u32>,
     /// Size of the response
     /// Since Scylla 3.0
     /// Not present in Cassandra
-    pub response_size: i32,
+    pub response_size: Option<u32>,
     /// The username associated with the request? Lacking documentation.
     /// Not present in Cassandra
-    pub username: String,
+    pub username: Option<String>,
 
     root_events: Vec<Event>,
 }
@@ -82,15 +82,15 @@ impl Session {
         Self {
             id: session_record.session_id,
             client: session_record.client,
-            command: session_record.command(),
+            command: session_record.command,
             coordinator: session_record.coordinator,
             duration: Duration::microseconds(session_record.duration.into()),
-            parameters: session_record.parameters(),
-            request: session_record.request(),
+            parameters: session_record.parameters,
+            request: session_record.request,
             request_size: session_record.request_size,
             response_size: session_record.response_size,
             started_at: session_record.started_at,
-            username: session_record.username(),
+            username: session_record.username,
             root_events: root_events.into(),
         }
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -23,17 +23,36 @@ use uuid::Uuid;
 /// i.e. we provide the children of the first root trace before moving on to the second root trace.
 #[derive(Debug)]
 pub struct Session {
+    /// The UUID of the Session
     pub id: Uuid,
+    /// The IP address of the connecting client
     pub client: IpAddr,
+    /// Currently, this can only be "QUERY"
     pub command: String,
+    /// The IP address of the coordinating Scylla Node
     pub coordinator: IpAddr,
+    /// Total duration of the Session
     pub duration: Duration,
+    /// A scylla map containing string pairs that describe the query
+    // Not currently parsing as a HashMap<String, String> due to issues with quoting
     pub parameters: String,
+    /// A short string decribing the Session. Is _not_ the CQL query being ran; that is in `parameters`.
     pub request: String,
-    pub request_size: i32,
-    pub response_size: i32,
+    /// DateTime of the start of this tracing session
     pub started_at: DateTime<FixedOffset>,
+
+    /// Size of the request
+    /// Since Scylla 3.0
+    /// Not present in Cassandra
+    pub request_size: i32,
+    /// Size of the response
+    /// Since Scylla 3.0
+    /// Not present in Cassandra
+    pub response_size: i32,
+    /// The username associated with the request? Lacking documentation.
+    /// Not present in Cassandra
     pub username: String,
+
     root_events: Vec<Event>,
 }
 

--- a/tests/74ff67c0-397b-11ee-8ca4-9688db6cc0f1.snapshot
+++ b/tests/74ff67c0-397b-11ee-8ca4-9688db6cc0f1.snapshot
@@ -3,7 +3,7 @@ Session ID: 74ff67c0-397b-11ee-8ca4-9688db6cc0f1
 172.17.0.2      (anonymous) -> 172.17.0.2     
 Request Size:  84
 Response Size: 20
-QUERY Execute CQL3 query
+Execute CQL3 query
 "{'consistency_level': 'ONE', 'page_size': '100', 'query': 'INSERT INTO k.t (pk, t, v, s) VALUES (0, 1, ''val1'', ''static1'');', 'serial_consistency_level': 'SERIAL', 'user_timestamp': '1691891290172041'}"
 
    waterfall chart                                      dur    node                activity                                                                                 event id                              span id              parent span id       thread name


### PR DESCRIPTION
Make the fields that aren't present in Cassandra `Option<T>`, and do the preparation work to generalize over the data source, making it possible to query from not only CSVs but also a live DB in the future.